### PR TITLE
Remove backticks (codeblocks) from markdown

### DIFF
--- a/_posts/2015-10-04-WhatAreChords.md
+++ b/_posts/2015-10-04-WhatAreChords.md
@@ -6,22 +6,22 @@ categories: terminology
 tags: [chord, chords, learning, terminology, piano, guitar, stringed, instruments, instrument]
 img: what-are-chords.png
 ---
-A chord is a combination of two or more notes played simultaneously. There you go! That's the end of the blog.
+A **chord** is a combination of two or more notes played simultaneously. There you go! That's the end of the blog.
 
-Kidding, of course. Chords are, by definition, very simple, but they come in all shapes and flavours. On a piano, the most common chord for any beginner to learn is the three-note major chord whereas many guitarists tend to learn the easy-to-play two-note power chord.
+Kidding, of course. Chords are, by definition, very simple, but they come in all shapes and flavours. On a piano, the most common chord for any beginner to learn is the three-note **major chord** whereas many guitarists tend to learn the easy-to-play two-note **power chord**.
 
-Chords are constructed of notes that come from a scale. For instance, the C major scale, which is arguably the most popularly taught first scale, is made up of the following notes (and the intervals those notes represent):
+Chords are constructed of notes that come from a **scale**. For instance, the **C Major** scale, which is arguably the most popularly taught first scale, is made up of the following notes (and the intervals those notes represent):
 
- - C (Root Note or R)
- - D (Major Second or M2)
- - E (Major Third or M3)
- - F (Perfect Fourth or P4)
- - G (Perfect Fifth or P5)
- - A (Major Sixthor  M6)
- - B (Major Seventh or M7)
- - C (Octave/Perfect Eighth or P8)\*
+ - C (Root Note - R)
+ - D (Major Second - M2)
+ - E (Major Third - M3)
+ - F (Perfect Fourth - P4)
+ - G (Perfect Fifth - P5)
+ - A (Major Sixthor - M6)
+ - B (Major Seventh - M7)
+ - C (Octave/Perfect Eighth - P8)
 
-When we define a chord, we usually refer to its composition not by the specific notes, but by the intervals that are used. For a primer on intervals, read [this]. The Cole's Notes is that intervals are the gaps between notes.
+When we define a chord, we usually refer to its composition not by the specific notes, but by the **intervals** that are used. For a primer on intervals, read [this]. The Cole's Notes is that intervals are the names we give the distances between notes.
 
 So, back to chords. A major chord is always comprised of three intervals:
 
@@ -31,18 +31,20 @@ Perfect Fifth (P5)
 
 ![C Major Intervals](/assets/img/whatarechords/c-major-intervals.png)
 
-Let's make a C Major chord! Looking at the list above we see that C is the root note. We know we need a major third and a perfect fifth. Without reading further, can you figure out which three chords make up the C Major chord?
+Let's make a **C Major** chord! Looking at the list above we see that **C** is the root note. We know we also need a **major third** and a **perfect fifth**. Without reading further, can you figure out which three chords make up the C Major chord?
 
 If not, that's OK! The answer is:
 
-C E G
+**C E G**
 
 ![C Major chord on a stave](/assets/img/whatarechords/c-major-chord.png)
 
- Now you can play a C Major chord simply by finding those three notes on your instrument and playing them in unison. Likewise, if you see those three notes appear vertically aligned on a staff then you know what you are dealing with!
+Now you can play a C Major chord simply by finding those three notes on your instrument and playing them in unison. Likewise, if you see those three notes appear vertically aligned on a staff then you know what you are dealing with!
 
- Chords have lots of variants like: minor (where the Major Third is flatted to a Minor Third), and Major Seventh (where we add a Major Seventh to the chord making it a four-note chord). Chords have many variants; this list is hardly exhaustive!
+Chords have lots of variants like: **minor** (where the **major third** is flatted to a **minor third**), and **major seventh** (where we add a **major seventh** to the chord making it a four-note chord). Chords have many variants; this list is hardly exhaustive!
 
- Now that you've gotten a taste about what chords are, you may find it useful to refresh your memory about scales and intervals!
+Now that you've gotten a taste about what chords are, you may find it useful to refresh your memory about [scales] and [intervals]!
 
- [this]: https://en.wikipedia.org/wiki/Interval_(music)
+[this]: /terminology/WhatAreIntervals/
+[scales]: /terminology/WhatAreScales/
+[intervals]: /terminology/WhatAreIntervals/

--- a/_posts/2015-10-04-WhatAreChords.md
+++ b/_posts/2015-10-04-WhatAreChords.md
@@ -8,7 +8,7 @@ img: what-are-chords.png
 ---
 A chord is a combination of two or more notes played simultaneously. There you go! That's the end of the blog.
 
-Kidding, of course. Chords are, by definition, very simple, but they come in all shapes and flavours. On a piano, the most common chord for any beginner to learn is the three-note `major chord` whereas many guitarists tend to learn the easy-to-play two-note `power chord`.
+Kidding, of course. Chords are, by definition, very simple, but they come in all shapes and flavours. On a piano, the most common chord for any beginner to learn is the three-note major chord whereas many guitarists tend to learn the easy-to-play two-note power chord.
 
 Chords are constructed of notes that come from a scale. For instance, the C major scale, which is arguably the most popularly taught first scale, is made up of the following notes (and the intervals those notes represent):
 
@@ -31,17 +31,17 @@ Perfect Fifth (P5)
 
 ![C Major Intervals](/assets/img/whatarechords/c-major-intervals.png)
 
-Let's make a `C Major` chord! Looking at the list above we see that `C` is the root note. We know we need a major third and a perfect fifth. Without reading further, can you figure out which three chords make up the `C Major` chord?
+Let's make a C Major chord! Looking at the list above we see that C is the root note. We know we need a major third and a perfect fifth. Without reading further, can you figure out which three chords make up the C Major chord?
 
 If not, that's OK! The answer is:
 
-```C E G```
+C E G
 
 ![C Major chord on a stave](/assets/img/whatarechords/c-major-chord.png)
 
- Now you can play a `C Major` chord simply by finding those three notes on your instrument and playing them in unison. Likewise, if you see those three notes appear vertically aligned on a staff then you know what you are dealing with!
+ Now you can play a C Major chord simply by finding those three notes on your instrument and playing them in unison. Likewise, if you see those three notes appear vertically aligned on a staff then you know what you are dealing with!
 
- Chords have lots of variants like: `minor` (where the Major Third is flatted to a Minor Third), and `Major Seventh` (where we add a Major Seventh to the chord making it a four-note chord). Chords have many variants; this list is hardly exhaustive!
+ Chords have lots of variants like: minor (where the Major Third is flatted to a Minor Third), and Major Seventh (where we add a Major Seventh to the chord making it a four-note chord). Chords have many variants; this list is hardly exhaustive!
 
  Now that you've gotten a taste about what chords are, you may find it useful to refresh your memory about scales and intervals!
 

--- a/_posts/2015-10-08-WhatAreIntervals.md
+++ b/_posts/2015-10-08-WhatAreIntervals.md
@@ -10,9 +10,9 @@ At its most basic definition, an interval is simply the distance between two not
 
 In music, we name these distances because intervals mean a lot to us and names help give things context. Let's start with an example.
 
-The C-Major scale, which is one of the first things musicians are often taught, goes: `C D E F G A B C`. It's an easy beginner scale because it doesn't incorporate any sharps or flats and, on the piano, is played all on the white keys. Many people also learn as children of *solfege*: `Do Re Mi Fa So La Ti Do`. Solfege is traditionally the singing of all notes (and therefore the intervals) of the C-Major scale.
+The C-Major scale, which is one of the first things musicians are often taught, goes: C D E F G A B C. It's an easy beginner scale because it doesn't incorporate any sharps or flats and, on the piano, is played all on the white keys. Many people also learn as children of *solfege*: Do Re Mi Fa So La Ti Do. Solfege is traditionally the singing of all notes (and therefore the intervals) of the C-Major scale.
 
-OK - I haven't actually talked about intervals yet. The most basic interval (and the interval that must exist in any equation) is the `root note`. The root note is the note that the scale or interval is based on -- in our above example, it's the first `C`. Technically speaking, the root note isn't an interval, but rather it is the anchor for other intervals. The interval distance from the root note to the root note (in other words, the same note twice) is referred to as a `unison` interval.
+OK - I haven't actually talked about intervals yet. The most basic interval (and the interval that must exist in any equation) is the root note. The root note is the note that the scale or interval is based on -- in our above example, it's the first C. Technically speaking, the root note isn't an interval, but rather it is the anchor for other intervals. The interval distance from the root note to the root note (in other words, the same note twice) is referred to as a unison interval.
 
 In the table below, I'll list each note in the C major scale and the named interval it represents in that scale.
 
@@ -27,9 +27,9 @@ In the table below, I'll list each note in the C major scale and the named inter
 |7            | B         | major seventh             |
 |8            | C         | octave / perfect eighth   |  
 
-As you can see, each interval name aligns with its position in the scale relative to the root (1) note. A `perfect fourth` is the fourth interval in the scale (again, including the root as 1).
+As you can see, each interval name aligns with its position in the scale relative to the root (1) note. A perfect fourth is the fourth interval in the scale (again, including the root as 1).
 
-Those are the notes that make up the `C-Major` scale, but of course they aren't "all" of the notes on a typical Western instrument. Here is a list (from `C` to `C`) of all intervals:
+Those are the notes that make up the C-Major scale, but of course they aren't "all" of the notes on a typical Western instrument. Here is a list (from C to C) of all intervals:
 
 |Note # | Note Name | Interval Name             |
 |---    |---        |-------------------------  |
@@ -47,13 +47,13 @@ Those are the notes that make up the `C-Major` scale, but of course they aren't 
 | 12    | B         | major seventh             |
 | 13    | C         | octave / perfect eighth   |
 
-You may be asking, "Why did you list the notes as flats instead of sharps"? In other words, why have I listed Db as the minor second instead of C# since they are the "same note"? See [enharmonic equivalents] for a background, but otherwise know this - `C#`/`Db` are the same pitch, but are referred to differently depending on the context. Clear as mud? Click the enharmonic link.
+You may be asking, "Why did you list the notes as flats instead of sharps"? In other words, why have I listed Db as the minor second instead of C# since they are the "same note"? See [enharmonic equivalents] for a background, but otherwise know this - C#/Db are the same pitch, but are referred to differently depending on the context. Clear as mud? Click the enharmonic link.
 
-Here is the easiest way to explain (and show) why we used `Db` in this case: The distance from C to D on a stave is one space. Therefore the distance between C and Db is also one space (though the note on the D line is flatted, obviously). If we used C# instead then both notes would both be on the C line and would not make sense spatially. So even though they sound the same, it is not "technically" correct. See the example below:
+Here is the easiest way to explain (and show) why we used Db in this case: The distance from C to D on a stave is one space. Therefore the distance between C and Db is also one space (though the note on the D line is flatted, obviously). If we used C# instead then both notes would both be on the C line and would not make sense spatially. So even though they sound the same, it is not "technically" correct. See the example below:
 
 ![Enharmonic Intervals](/assets/img/whatareintervals/enharmonic-intervals.png)
 
-If you're a guitarist, pianist, or just curious, then you may want to read our article [What Are Chords?] because chords are defined and built using intervals! As an example, the popular three-note `major chord` is made up of the `root`, `major third`, and `perfect fifth` intervals!
+If you're a guitarist, pianist, or just curious, then you may want to read our article [What Are Chords?] because chords are defined and built using intervals! As an example, the popular three-note major chord is made up of the root, major third, and perfect fifth intervals!
 
 [enharmonic equivalents]: https://en.wikipedia.org/wiki/Enharmonic
 [What Are Chords?]: /terminology/WhatAreChords

--- a/_posts/2015-10-08-WhatAreIntervals.md
+++ b/_posts/2015-10-08-WhatAreIntervals.md
@@ -6,15 +6,15 @@ categories: terminology
 tags: [interval, intervals, learning, terminology, piano, guitar, stringed, instruments, instrument]
 img: piano-keys.png
 ---
-At its most basic definition, an interval is simply the distance between two notes.
+At its most basic definition, an **interval** is simply the distance between two notes.
 
 In music, we name these distances because intervals mean a lot to us and names help give things context. Let's start with an example.
 
-The C-Major scale, which is one of the first things musicians are often taught, goes: C D E F G A B C. It's an easy beginner scale because it doesn't incorporate any sharps or flats and, on the piano, is played all on the white keys. Many people also learn as children of *solfege*: Do Re Mi Fa So La Ti Do. Solfege is traditionally the singing of all notes (and therefore the intervals) of the C-Major scale.
+The **C Major** scale, which is one of the first things musicians are often taught, goes: **C - D - E - F - G - A - B - C**. It's an easy beginner scale because it doesn't incorporate any sharps or flats and, on the piano, is played all on the white keys. Many people also learn as children of *solfege*: **Do Re Mi Fa So La Ti Do**. Solfege is traditionally the singing of all notes (and therefore the intervals) of the C-Major scale.
 
-OK - I haven't actually talked about intervals yet. The most basic interval (and the interval that must exist in any equation) is the root note. The root note is the note that the scale or interval is based on -- in our above example, it's the first C. Technically speaking, the root note isn't an interval, but rather it is the anchor for other intervals. The interval distance from the root note to the root note (in other words, the same note twice) is referred to as a unison interval.
+OK - I haven't actually talked about intervals yet. The most basic interval (and the interval that must exist in any equation) is the **root note**. The root note is the note that a **scale** or **interval** is based on; in our above example, it's the first **C**. Technically speaking, the root note isn't an interval, but rather it is the anchor for other intervals. The interval distance from the root note to the root note (in other words, the same note twice) is referred to as a **unison interval**.
 
-In the table below, I'll list each note in the C major scale and the named interval it represents in that scale.
+In the table below, I'll list each note in the C Major scale and the named interval it represents in that scale.
 
 | Note #      | Note Name | Interval Name             |
 |---          |---        |-------------------------  |
@@ -27,9 +27,9 @@ In the table below, I'll list each note in the C major scale and the named inter
 |7            | B         | major seventh             |
 |8            | C         | octave / perfect eighth   |  
 
-As you can see, each interval name aligns with its position in the scale relative to the root (1) note. A perfect fourth is the fourth interval in the scale (again, including the root as 1).
+As you can see, each interval name aligns with its position in the scale relative to the root (1) note. A **perfect fourth** is the fourth interval in the scale (again, including the root as 1).
 
-Those are the notes that make up the C-Major scale, but of course they aren't "all" of the notes on a typical Western instrument. Here is a list (from C to C) of all intervals:
+Those are the notes that make up the C-Major scale, but of course they aren't "all" of the notes on a typical Western instrument. Here is a list (from C to C) of *all* intervals:
 
 |Note # | Note Name | Interval Name             |
 |---    |---        |-------------------------  |
@@ -47,13 +47,13 @@ Those are the notes that make up the C-Major scale, but of course they aren't "a
 | 12    | B         | major seventh             |
 | 13    | C         | octave / perfect eighth   |
 
-You may be asking, "Why did you list the notes as flats instead of sharps"? In other words, why have I listed Db as the minor second instead of C# since they are the "same note"? See [enharmonic equivalents] for a background, but otherwise know this - C#/Db are the same pitch, but are referred to differently depending on the context. Clear as mud? Click the enharmonic link.
+You may be asking, "Why did you list the notes as flats instead of sharps"? In other words, why have I listed **Db** as the **minor second** instead of C# since they are the "same note"? See [enharmonic equivalents] for a background, but otherwise know this - **C# / Db** are the same pitch, but are referred to differently depending on the context. Clear as mud? Click the enharmonic link.
 
-Here is the easiest way to explain (and show) why we used Db in this case: The distance from C to D on a stave is one space. Therefore the distance between C and Db is also one space (though the note on the D line is flatted, obviously). If we used C# instead then both notes would both be on the C line and would not make sense spatially. So even though they sound the same, it is not "technically" correct. See the example below:
+Here is the easiest way to explain (and show) why we used **Db** in this case: The distance from **C** to **D** on a stave is one space. Therefore the distance between **C** and **Db** is also one space (though the note on the D line is flatted). If we used C# instead then both notes would both be on the C line and would not make sense spatially. So even though they sound the same, it is not "technically" correct. See the example below:
 
 ![Enharmonic Intervals](/assets/img/whatareintervals/enharmonic-intervals.png)
 
-If you're a guitarist, pianist, or just curious, then you may want to read our article [What Are Chords?] because chords are defined and built using intervals! As an example, the popular three-note major chord is made up of the root, major third, and perfect fifth intervals!
+If you're a guitarist, pianist, or just curious, then you may want to read our article [What Are Chords?] because chords are defined and built using intervals! As an example, the popular three-note **major chord** is made up of the root, major third, and perfect fifth intervals!
 
-[enharmonic equivalents]: https://en.wikipedia.org/wiki/Enharmonic
+[enharmonic equivalents]: /terminology/WhatAreEnharmonics
 [What Are Chords?]: /terminology/WhatAreChords

--- a/_posts/2015-10-11-WhatAreEnharmonics.md
+++ b/_posts/2015-10-11-WhatAreEnharmonics.md
@@ -8,19 +8,19 @@ img: whatareenharmonics/sheet-music.jpg
 ---
 Have you ever heard people throwing the word "enharmonic" around and wondered just what the heck they were talking about? It turns out it is a complicated-sounding term for a fairly simple concept.
 
-Enharmonic equivalents are two different notes that, when played, are actually the same pitch. As a quick example: `C#` is the same as `Db`. Enharmonic equivalents can also be applied to key signatures and intervals. These labeled piano keys can serve as a reference for the basic enharmonic notes:
+Enharmonic equivalents are two different notes that, when played, are actually the same pitch. As a quick example: C# is the same as Db. Enharmonic equivalents can also be applied to key signatures and intervals. These labeled piano keys can serve as a reference for the basic enharmonic notes:
 
 ![Labeled Piano](/assets/img/labeled-piano.png)
 
-There are many reasons why we call the same pitch by two different names, but it's easy to explain with the following image. We are going to incorrectly then correctly place a `minor second` interval for `C`. If you want a refresher on intervals, check out our post ["What are Intervals?"]!
+There are many reasons why we call the same pitch by two different names, but it's easy to explain with the following image. We are going to incorrectly then correctly place a minor second interval for C. If you want a refresher on intervals, check out our post ["What are Intervals?"]!
 
 ![Enharmonic Equivalents](/assets/img/whatareintervals/enharmonic-intervals.png)
 
-In the image above, you can see that we have written `C#` and `Db` as a `minor second` interval of `C`. `C -> C#` is correct as far as pitch goes -- if you sounded a `C#` on your instrument that would be right (and would be the same as sounding a `Db`!) But, spatially speaking, it is incorrect when we're looking at a stave. Intervals should not occur on the same line, which is what happens if we need to sharpen `C` to `C#` and therefore the `minor second`. How do we fix this? Easy! We move up to the `D` line and flatten the `D` instead.
+In the image above, you can see that we have written C# and Db as a minor second interval of C. C -> C# is correct as far as pitch goes -- if you sounded a C# on your instrument that would be right (and would be the same as sounding a Db!) But, spatially speaking, it is incorrect when we're looking at a stave. Intervals should not occur on the same line, which is what happens if we need to sharpen C to C# and therefore the minor second. How do we fix this? Easy! We move up to the D line and flatten the D instead.
 
-From this example, we can see that the `minor second` interval in both the "right" and "wrong" examples are the same pitch, but two differently named notes: `C#` and `Db`! These two notes are `enharmonic` or `enharmonic equivalents`.
+From this example, we can see that the minor second interval in both the "right" and "wrong" examples are the same pitch, but two differently named notes: C# and Db! These two notes are enharmonic or enharmonic equivalents.
 
-Less common, but still something musicians should know, are double sharps and double flats. If a single sharp raises a note by a `half-tone` (otherwise known as a `semitone`) then a double sharp does twice that - it raises a note by a `whole-tone` (or just a `tone`). The same goes for flats, but in the opposite direction: since a flat lowers a note by a `semitone`, a double flat lowers our note by a `whole-tone`. In music notation, a double sharp is written as `x` like: `Dx`. Double flats are written as `bb` like: `Dbb`.
+Less common, but still something musicians should know, are double sharps and double flats. If a single sharp raises a note by a half-tone (otherwise known as a semitone) then a double sharp does twice that - it raises a note by a whole-tone (or just a tone). The same goes for flats, but in the opposite direction: since a flat lowers a note by a semitone, a double flat lowers our note by a whole-tone. In music notation, a double sharp is written as x like: Dx. Double flats are written as bb like: Dbb.
 
 Sometimes in music it's best to remember that certain things "just are the way they are". A great example of this is trying to answer: "Why did we define the Major Scale the way we did?" The answer is: because we did.
 

--- a/_posts/2015-10-11-WhatAreEnharmonics.md
+++ b/_posts/2015-10-11-WhatAreEnharmonics.md
@@ -8,19 +8,19 @@ img: whatareenharmonics/sheet-music.jpg
 ---
 Have you ever heard people throwing the word "enharmonic" around and wondered just what the heck they were talking about? It turns out it is a complicated-sounding term for a fairly simple concept.
 
-Enharmonic equivalents are two different notes that, when played, are actually the same pitch. As a quick example: C# is the same as Db. Enharmonic equivalents can also be applied to key signatures and intervals. These labeled piano keys can serve as a reference for the basic enharmonic notes:
+**Enharmonic equivalents** are two different notes that, when played, actually sound the same pitch. As a quick example: **C#** is the same as **Db**. Enharmonic equivalents can also be applied to **key signatures** and **intervals**. These labeled piano keys can serve as a reference for the basic enharmonic notes:
 
 ![Labeled Piano](/assets/img/labeled-piano.png)
 
-There are many reasons why we call the same pitch by two different names, but it's easy to explain with the following image. We are going to incorrectly then correctly place a minor second interval for C. If you want a refresher on intervals, check out our post ["What are Intervals?"]!
+There are many reasons why we call the same pitch by two different names, but it's easy to explain with the following image. We are going to incorrectly then correctly place a **minor second** interval for **C**. If you want a refresher on **intervals**, check out our post ["What are Intervals?"]!
 
 ![Enharmonic Equivalents](/assets/img/whatareintervals/enharmonic-intervals.png)
 
-In the image above, you can see that we have written C# and Db as a minor second interval of C. C -> C# is correct as far as pitch goes -- if you sounded a C# on your instrument that would be right (and would be the same as sounding a Db!) But, spatially speaking, it is incorrect when we're looking at a stave. Intervals should not occur on the same line, which is what happens if we need to sharpen C to C# and therefore the minor second. How do we fix this? Easy! We move up to the D line and flatten the D instead.
+In the image above, you can see that we have written **C#** and **Db** as a **minor second** interval of C. **C -> C#** is correct as far as pitch goes; if you sounded a C# on your instrument that would be right (and would be the same as sounding a Db). But, spatially speaking, it is incorrect if we are looking at a stave. Intervals should not occur on the same line, which is what happens if we need to sharpen C to C# to get a minor second. How do we fix this? Easy! We move up to the **D** line and flatten the D instead.
 
-From this example, we can see that the minor second interval in both the "right" and "wrong" examples are the same pitch, but two differently named notes: C# and Db! These two notes are enharmonic or enharmonic equivalents.
+From this example, we can see that the minor second interval in both the "right" and "wrong" examples are the same pitch, but are two differently named notes: C# and Db! These two notes are **enharmonic** or **enharmonic equivalents**.
 
-Less common, but still something musicians should know, are double sharps and double flats. If a single sharp raises a note by a half-tone (otherwise known as a semitone) then a double sharp does twice that - it raises a note by a whole-tone (or just a tone). The same goes for flats, but in the opposite direction: since a flat lowers a note by a semitone, a double flat lowers our note by a whole-tone. In music notation, a double sharp is written as x like: Dx. Double flats are written as bb like: Dbb.
+Less common, but still something musicians should know, are **double sharps** and **double flats**. If a single sharp raises a note by a **half-tone** (otherwise known as a **semitone**) then a double sharp does twice that - it raises a note by a **whole-tone**. The same goes for flats, but in the opposite direction - since a flat lowers a note by a semitone, a double flat lowers our note by a whole-tone. In music notation, a double sharp is written as 'x' like: **Dx**. Double flats are written as 'bb' like: **Dbb**.
 
 Sometimes in music it's best to remember that certain things "just are the way they are". A great example of this is trying to answer: "Why did we define the Major Scale the way we did?" The answer is: because we did.
 

--- a/_posts/2015-10-13-WhatAreScales.md
+++ b/_posts/2015-10-13-WhatAreScales.md
@@ -6,14 +6,14 @@ categories: terminology
 tags: [scale, scales, major, minor, learning, terminology, piano, guitar, instruments, instrument]
 img: whatarescales/weigh-scale.jpg
 ---
-A scale is simply a collection of notes that has a predefined order or pattern it follows. The most well known scale in Western music is the C Major scale. All major scales follow the same pattern of whole-tones and half-tones (otherwise known as a semitone).
+A scale is simply a collection of notes that has a predefined order or pattern it follows. The most well known scale in Western music is the **C Major** scale. All major scales follow the same pattern of whole-tones and half-tones (otherwise known as a semitone).
 
 Major scales follow this pattern:
-W - W - H - W - W - W - H
+**W - W - H - W - W - W - H**
 
-Something to remember: the first note in a scale is called the root note or the tonic (from the word tone, not the popular additive to gin cocktails.)
+Something to remember: the first note in a scale is called the **root note** or the **tonic** (from the word tone, not the popular additive to gin cocktails.)
 
-Let's break one down in text before we look at it on the stave. We'll make a little scale formula table:
+Let's break a major scale down. We'll make a little scale formula table:
 
 | Note Name | + W or H      | = Next Note |
 |---        |---            |---          |
@@ -25,14 +25,14 @@ Let's break one down in text before we look at it on the stave. We'll make a lit
 | A         | W             | B           |
 | B         | H             | C           |
 
-Let's take a quick look at what is happening in that table. The starting note C is the root note or tonic. When we add a whole-tone to it we get D (a half-tone or semitone would give us C#). Next, we start on D and using our scale formula we know that we are to add another whole-tone since this is a major scale. D plus another whole-tone gives us E. Now, we move on to the first half-tone or semitone in the formula: E plus a half-tone gives us F. Follow the table back down the list and see how each note yields the following note in the scale simply by using this formula.
+Let's take a quick look at what is happening in that table. The starting note **C** is the root note or tonic. When we add a whole-tone to it we get **D** (a half-tone or semitone would give us Db, which is incorrect). Next, we start on **D** and using our scale formula we know that we are to add another whole-tone since this is a major scale. D plus another whole-tone gives us **E**. Now, we move on to the first half-tone or semitone in the formula: E plus a half-tone gives us **F**. Follow the table back down the list and see how each note yields the following note in the scale simply by using this formula.
 
-If you line up the letters in the left-most column of this table, you'll see that we have the C Major scale:   
-C - D - E - F - G - A - B - C
+If you line up the letters in the left-most column of this table, you'll see that we have the **C Major** scale:   
+**C - D - E - F - G - A - B - C**
 
-So, why are most musicians taught C Major as their first scale? It's simple - there are no sharps or flats in this scale. In fact, it's the only major scale without any accidentals (which is the name for things like sharps, flats, and certain other notative symbols on a stave). Therefore, on a piano, C Major is played exclusively on the white keys making it an easy scale to learn. The rest of us who aren't pianists usually just follow the same basic structure when first learning. Awesome trivia time -- traditionally, the C Major scale is the base scale for *solfege*: the Do Re Mi Fa So La Ti Do tune many of us learn as kids.
+So, why are most musicians taught C Major as their first scale? It's simple - there are no sharps or flats in this scale. In fact, it's the only major scale without any **accidentals** (which is the name for things like sharps, flats, and certain other notative symbols on a stave). Therefore, on a piano, C Major is played exclusively on the white keys making it an easy scale to learn. The rest of us who aren't pianists usually just follow the same basic structure when first learning. Trivia time: traditionally, the C Major scale is the base scale for *solfege*: the **Do Re Mi Fa So La Ti Do** tune many of us learn as kids.
 
-Want to do see another major scale example? Check out Ab major:
+Want to do see another major scale example? Check out **Ab Major**:
 
 | Note Name  | + W or H      | = Next Note  |
 |---         |---            |---           |
@@ -45,13 +45,13 @@ Want to do see another major scale example? Check out Ab major:
 | G          | H             | Ab           |
 
 Whoa! There we go, now we've got something that looks complex. But it's not - this follows the exact same pattern as the above C Major example. Let's break it down:
-Ab is our root note or tonic. Ab to Bb is a whole-tone. Bb to C is a whole-tone. Then we hit our first half-tone increment which is: C to Db. If you follow from here on your own, it will work out - trust me! Again, we can take all of the letters in the left-most column and use them to create the Ab Major scale:   
-Ab - Bb - C - Db - Eb - F - G - Ab
+**Ab** is our root note or tonic. Ab to **Bb** is a whole-tone. Bb to **C** is a whole-tone. Then we hit our first half-tone increment which is: C to **Db**. If you follow from here on your own, it will work out - trust me! Again, we can take all of the letters in the left-most column and use them to create the **Ab Major** scale:   
+**Ab - Bb - C - Db - Eb - F - G - Ab**
 
 Minor scales have a different formula:
 W - H - W - W - H - W - W
 
-We'll do one example of a minor scale then call it day on this post. Let's try C minor.
+We'll do one example of a minor scale then call it day on this post. Let's try **C minor**.
 
 | Note Name | + W or H      | = Next Note |
 |---        |---            |---          |
@@ -63,6 +63,6 @@ We'll do one example of a minor scale then call it day on this post. Let's try C
 | Ab        | W             | Bb          |
 | Bb        | W             | C           |
 
-The resulting scale? C - D - Eb - F - G - Ab - Bb - C.
+The resulting scale? **C - D - Eb - F - G - Ab - Bb - C**.
 
 There are **many** more scales and scale patterns out there, but they are certainly deserving of a separate post. For now, just remember: a scale is nothing but a grouping of notes that adheres to a pattern. If you can remember the pattern, then you can figure out any scale simply by starting with the tonic and going from there!

--- a/_posts/2015-10-13-WhatAreScales.md
+++ b/_posts/2015-10-13-WhatAreScales.md
@@ -6,12 +6,12 @@ categories: terminology
 tags: [scale, scales, major, minor, learning, terminology, piano, guitar, instruments, instrument]
 img: whatarescales/weigh-scale.jpg
 ---
-A scale is simply a collection of notes that has a predefined order or pattern it follows. The most well known scale in Western music is the `C Major` scale. All `major scales` follow the same pattern of `whole-tones` and `half-tones` (otherwise known as a `semitone`).
+A scale is simply a collection of notes that has a predefined order or pattern it follows. The most well known scale in Western music is the C Major scale. All major scales follow the same pattern of whole-tones and half-tones (otherwise known as a semitone).
 
 Major scales follow this pattern:
-`W - W - H - W - W - W - H`
+W - W - H - W - W - W - H
 
-Something to remember: the first note in a scale is called the `root` note or the `tonic` (from the word `tone`, not the popular additive to gin cocktails.)
+Something to remember: the first note in a scale is called the root note or the tonic (from the word tone, not the popular additive to gin cocktails.)
 
 Let's break one down in text before we look at it on the stave. We'll make a little scale formula table:
 
@@ -25,12 +25,12 @@ Let's break one down in text before we look at it on the stave. We'll make a lit
 | A         | W             | B           |
 | B         | H             | C           |
 
-Let's take a quick look at what is happening in that table. The starting note `C` is the root note or tonic. When we add a `whole-tone` to it we get `D` (a `half-tone` or `semitone` would give us `C#`). Next, we start on `D` and using our scale formula we know that we are to add another `whole-tone` since this is a `major scale`. `D` plus another `whole-tone` gives us `E`. Now, we move on to the first `half-tone` or `semitone` in the formula: `E` plus a `half-tone` gives us `F`. Follow the table back down the list and see how each note yields the following note in the scale simply by using this formula.
+Let's take a quick look at what is happening in that table. The starting note C is the root note or tonic. When we add a whole-tone to it we get D (a half-tone or semitone would give us C#). Next, we start on D and using our scale formula we know that we are to add another whole-tone since this is a major scale. D plus another whole-tone gives us E. Now, we move on to the first half-tone or semitone in the formula: E plus a half-tone gives us F. Follow the table back down the list and see how each note yields the following note in the scale simply by using this formula.
 
-If you line up the letters in the left-most column of this table, you'll see that we have the `C Major` scale:   
-`C - D - E - F - G - A - B - C`
+If you line up the letters in the left-most column of this table, you'll see that we have the C Major scale:   
+C - D - E - F - G - A - B - C
 
-So, why are most musicians taught `C Major` as their first scale? It's simple - there are no sharps or flats in this scale. In fact, it's the only major scale without any accidentals (which is the name for things like sharps, flats, and certain other notative symbols on a stave). Therefore, on a piano, `C Major` is played exclusively on the white keys making it an easy scale to learn. The rest of us who aren't pianists usually just follow the same basic structure when first learning. Awesome trivia time -- traditionally, the `C Major` scale is the base scale for *solfege*: the `Do Re Mi Fa So La Ti Do` tune many of us learn as kids.
+So, why are most musicians taught C Major as their first scale? It's simple - there are no sharps or flats in this scale. In fact, it's the only major scale without any accidentals (which is the name for things like sharps, flats, and certain other notative symbols on a stave). Therefore, on a piano, C Major is played exclusively on the white keys making it an easy scale to learn. The rest of us who aren't pianists usually just follow the same basic structure when first learning. Awesome trivia time -- traditionally, the C Major scale is the base scale for *solfege*: the Do Re Mi Fa So La Ti Do tune many of us learn as kids.
 
 Want to do see another major scale example? Check out Ab major:
 
@@ -44,14 +44,14 @@ Want to do see another major scale example? Check out Ab major:
 | F          | W             | G            |
 | G          | H             | Ab           |
 
-Whoa! There we go, now we've got something that looks complex. But it's not - this follows the exact same pattern as the above `C Major` example. Let's break it down:
-`Ab` is our `root` note or `tonic`. `Ab` to `Bb` is a `whole-tone`. `Bb` to `C` is a `whole-tone`. Then we hit our first `half-tone` increment which is: `C` to `Db`. If you follow from here on your own, it will work out - trust me! Again, we can take all of the letters in the left-most column and use them to create the `Ab Major` scale:   
-`Ab - Bb - C - Db - Eb - F - G - Ab`
+Whoa! There we go, now we've got something that looks complex. But it's not - this follows the exact same pattern as the above C Major example. Let's break it down:
+Ab is our root note or tonic. Ab to Bb is a whole-tone. Bb to C is a whole-tone. Then we hit our first half-tone increment which is: C to Db. If you follow from here on your own, it will work out - trust me! Again, we can take all of the letters in the left-most column and use them to create the Ab Major scale:   
+Ab - Bb - C - Db - Eb - F - G - Ab
 
-`Minor` scales have a different formula:
-`W - H - W - W - H - W - W`
+Minor scales have a different formula:
+W - H - W - W - H - W - W
 
-We'll do one example of a minor scale then call it day on this post. Let's try `C minor`.
+We'll do one example of a minor scale then call it day on this post. Let's try C minor.
 
 | Note Name | + W or H      | = Next Note |
 |---        |---            |---          |
@@ -63,6 +63,6 @@ We'll do one example of a minor scale then call it day on this post. Let's try `
 | Ab        | W             | Bb          |
 | Bb        | W             | C           |
 
-The resulting scale? `C - D - Eb - F - G - Ab - Bb - C`.
+The resulting scale? C - D - Eb - F - G - Ab - Bb - C.
 
-There are **many** more scales and scale patterns out there, but they are certainly deserving of a separate post. For now, just remember: a scale is nothing but a grouping of notes that adheres to a pattern. If you can remember the pattern, then you can figure out any scale simply by starting with the `tonic` and going from there!
+There are **many** more scales and scale patterns out there, but they are certainly deserving of a separate post. For now, just remember: a scale is nothing but a grouping of notes that adheres to a pattern. If you can remember the pattern, then you can figure out any scale simply by starting with the tonic and going from there!


### PR DESCRIPTION
Was not happy with how fractured the code blocks ended up making the text look. Was only meant to help style, but in the end it just drove me nuts to look at.
